### PR TITLE
Move __version__ before REQUIREMENTS

### DIFF
--- a/custom_components/sensor/trakt.py
+++ b/custom_components/sensor/trakt.py
@@ -13,9 +13,9 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['trakt==2.8.2', 'requests_oauthlib==1.0.0']
-
 __version__ = '0.0.2'
+
+REQUIREMENTS = ['trakt==2.8.2', 'requests_oauthlib==1.0.0']
 
 CONF_CLIENT_ID = 'id'
 CONF_CLIENT_SECRET = 'secret'


### PR DESCRIPTION
It's a guess that this might work (not really able to test it). But since the version is displayed incorrectly in tracker-card (https://github.com/custom-components/information/pull/4) it could be that the version should be specified before REQUIREMENTS, which seem to match how other components does it.