### PR TITLE
Added example for lovelace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ sensor:
     'The Bachelor'
 ```
 
+### Example ui-lovelace.yaml:
+
+    - type: custom:upcoming-media-card
+      entity: sensor.upcoming_calendar
+      title: Upcoming Movies
+
 **Configuration variables:**
 
 key | type | description


### PR DESCRIPTION
I've added an example with the correct entity to be used in the lovelace UI, because it took me quite some time to figure out it was different then the sensor name's for the other implementations of upcoming-media-card.