### PR TITLE
Bump trakt to 2.14.0

### DIFF
--- a/custom_components/trakt/manifest.json
+++ b/custom_components/trakt/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/custom-components/sensor.trakt/blob/master/README.md",
   "config_flow": true,
   "codeowners": ["@iantrich", "@engrbm"],
-  "requirements": ["trakt==2.12.0"]
+  "requirements": ["trakt==2.14.0"]
 }


### PR DESCRIPTION
Bump trakt to 2.14.0.

Changes which affect the component:
- Exceptions are following proper inheritance now, this probably fixes #43, #41 as they seem to be related to trakt completely crashing home assistant due to wrong exception base class
- Automatic oauth token refresh

Tested on my local hass install, seems to be working without changes.